### PR TITLE
Only require event, others can be undefined.

### DIFF
--- a/src/yamlToAnalytics.ts
+++ b/src/yamlToAnalytics.ts
@@ -131,7 +131,7 @@ export default async (inDir: string, outFile: string) => {
         .concat(Object.keys(jsonzWithSubstituteRefs)
             .map((key) => jsonzWithSubstituteRefs[key].title)
             .map((title) =>
-`export const make${capNoSpace(title)} = (userId: string, properties: ${capNoSpace(title)}) => ({
+`export const make${capNoSpace(title)} = (userId?: string, properties?: ${capNoSpace(title)}) => ({
     userId,
     event: "${title}",
     properties,


### PR DESCRIPTION
This is required to allow us to track events not belonging to any `userId`. Segment allows to leave both `userId` and `properties` optional: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/analytics-node/index.d.ts#L62