### PR TITLE
Change user interface, allow passing anonymous user ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yaml-to-analytics",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "bin": "./dist/cli.js",
   "scripts": {

--- a/src/yamlToAnalytics.ts
+++ b/src/yamlToAnalytics.ts
@@ -3,7 +3,7 @@ import globSync from "glob";
 import yaml from "js-yaml";
 import { compileFromFile } from "json-schema-to-typescript";
 import clonedeep from "lodash.clonedeep";
-import { dirname, extname, isAbsolute, join, resolve } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import tmp from "tmp";
 import TopologicalSort from "topological-sort";
 import { promisify } from "util";
@@ -131,7 +131,7 @@ export const buildFileContents = async (inDir: string) => {
         .concat(Object.keys(jsonzWithSubstituteRefs)
             .map((key) => jsonzWithSubstituteRefs[key].title)
             .map((title) =>  // tslint:disable-next-line
-`export const make${capNoSpace(title)} = ({ userId, anonymousId, properties }: { userId?: string, anonymousId?: string, properties?: ${capNoSpace(title)} }) => ({
+`export const make${capNoSpace(title)} = ({ userId, anonymousId, properties }: { userId?: string, anonymousId?: string, properties: ${capNoSpace(title)} }) => ({
     userId,
     event: "${title}",
     properties,

--- a/src/yamlToAnalytics.ts
+++ b/src/yamlToAnalytics.ts
@@ -131,7 +131,7 @@ export const buildFileContents = async (inDir: string) => {
         .concat(Object.keys(jsonzWithSubstituteRefs)
             .map((key) => jsonzWithSubstituteRefs[key].title)
             .map((title) =>  // tslint:disable-next-line
-`export const make${capNoSpace(title)} = (userId?: string, properties?: ${capNoSpace(title)}, anonymousId?: string) => ({
+`export const make${capNoSpace(title)} = ({ userId, anonymousId, properties }: { userId?: string, anonymousId?: string, properties?: ${capNoSpace(title)} }) => ({
     userId,
     event: "${title}",
     properties,

--- a/src/yamlToAnalytics.ts
+++ b/src/yamlToAnalytics.ts
@@ -130,11 +130,12 @@ export const buildFileContents = async (inDir: string) => {
         .concat(tss)
         .concat(Object.keys(jsonzWithSubstituteRefs)
             .map((key) => jsonzWithSubstituteRefs[key].title)
-            .map((title) =>
-`export const make${capNoSpace(title)} = (userId?: string, properties?: ${capNoSpace(title)}) => ({
+            .map((title) =>  // tslint:disable-next-line
+`export const make${capNoSpace(title)} = (userId?: string, properties?: ${capNoSpace(title)}, anonymousId?: string) => ({
     userId,
     event: "${title}",
     properties,
+    anonymousId,
 });
 `));
     return file.join("\n");

--- a/test/yamlToAnalytics.test.ts
+++ b/test/yamlToAnalytics.test.ts
@@ -139,7 +139,7 @@ test("ts json to make correct type file", async () => {
   const analyticsModule = await import(tsDir);
   const userId = "foobar";
   const firstName = "first";
-  const registersAUserEvent = analyticsModule.makeRegistersAUser(userId, { firstName });
+  const registersAUserEvent = analyticsModule.makeRegistersAUser({ userId, properties: { firstName } });
   expect(registersAUserEvent.userId).toBe(userId);
   expect(registersAUserEvent.properties.firstName).toBe(firstName);
 });

--- a/test/yamlToAnalytics.test.ts
+++ b/test/yamlToAnalytics.test.ts
@@ -132,14 +132,28 @@ const buildYamlAndTsDirs = () => {
   return [yamlDir, tsDir];
 };
 
-test("ts json to make correct type file", async () => {
-  const [yamlDir, tsDir] = buildYamlAndTsDirs();
-  const targetTsFile = `${tsDir}/index.ts`;
-  await ymlFilesToTypeFile(`${yamlDir}/**/*.yml`, targetTsFile);
-  const analyticsModule = await import(tsDir);
+describe("Building TS from YAML spec", () => {
+  let tsDir: string;
+  let builtAnalyticsModule: any;
   const userId = "foobar";
-  const firstName = "first";
-  const registersAUserEvent = analyticsModule.makeRegistersAUser({ userId, properties: { firstName } });
-  expect(registersAUserEvent.userId).toBe(userId);
-  expect(registersAUserEvent.properties.firstName).toBe(firstName);
+  const anonymousId = "foobaranon";
+  const userProperties = { firstName: "first" };
+  beforeAll(async () => {
+    let yamlDir: string;
+    [yamlDir, tsDir] = buildYamlAndTsDirs();
+    const targetTsFile = `${tsDir}/index.ts`;
+    console.info(`Writing to ${targetTsFile}`);  // tslint:disable-line
+    await ymlFilesToTypeFile(`${yamlDir}/**/*.yml`, targetTsFile);
+    builtAnalyticsModule = await import(tsDir);
+  });
+  test("makes register a user event correctly", async () => {
+    const registersAUserEvent = builtAnalyticsModule.makeRegistersAUser({ userId, properties: userProperties });
+    expect(registersAUserEvent.userId).toBe(userId);
+    expect(registersAUserEvent.properties.firstName).toBe(userProperties.firstName);
+  });
+  test("makes register a user event with anonymous ID", async () => {
+    const registersAUserEvent = builtAnalyticsModule.makeRegistersAUser({ anonymousId, properties: { } });
+    expect(registersAUserEvent.userId).toBeUndefined();
+    expect(registersAUserEvent.anonymousId).toBe(anonymousId);
+  });
 });


### PR DESCRIPTION
- To allow passing in either `userId` or `anonymousId`
- Change the user interface of `makeEvent` to take in one object. This seems much more user-friendly with "either userId or anon ID" logic in place